### PR TITLE
chore: replace lsqlite3 lib with lsqlite3complete

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,0 @@
-[submodule "lua/projectmgr/deps/lua-ljsqlite3"]
-	path = lua/projectmgr/deps/lua-ljsqlite3
-	url = https://github.com/stepelu/lua-ljsqlite3.git
-[submodule "lua/projectmgr/deps/lua-xsys"]
-	path = lua/projectmgr/deps/lua-xsys
-	url = https://github.com/stepelu/lua-xsys.git

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The plugin is intended for use with packer, since a `luarocks` dependency exists
 ```lua
 use {
   'charludo/projectmgr.nvim',
-  rocks = {'lsqlite3'},
+  rocks = {'lsqlite3complete'},
 }
 ```
 

--- a/lua/projectmgr/db_adapter.lua
+++ b/lua/projectmgr/db_adapter.lua
@@ -1,4 +1,4 @@
-local sqlite = require("lsqlite3")
+local sqlite = require("lsqlite3complete")
 local db_path =
 	string.match(debug.getinfo(1, "S").source, "^@(.+/)[%a%-%d_]+%.lua$"):gsub("lua/projectmgr/", "projects.db")
 


### PR DESCRIPTION
implements the proposed changed from #7 

extra info: https://github.com/LuaDist-testing/lsqlite3complete

excerpts from README:
> There are two modules, identical except that one links SQLite3 dynamically, the other statically.
>
> The module lsqlite3complete links SQLite3 statically.