### PR TITLE
BREAKING improve autogit

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 - create a list of projects, then quickly switch between them
 - automate startup and shutdown tasks for each project:
-  - `git fetch` && `git pull` when entering the project
+  - pull from a remote when entering the project
   - custom startup command and/or script
   - custom shutdown command and/or script
 - save and restore sessions and shada files on a per-project base
@@ -56,7 +56,10 @@ use {
 
 ```lua
 {
-  autogit = false,
+  autogit = {
+    enabled = false,
+    command = "git pull --ff-only",
+  },
   reopen = false,
   session = { enabled = true, file = "Session.vim" },
   shada = { enabled = false, file = "main.shada" },
@@ -95,7 +98,7 @@ The following actions and keybinds are available:
 
 ### 🦑 Usage without `telescope.nvim`
 
-`projectmgr` comes with a fallback window in case you aren't using `telescope.nvim`. The same actions are available.
+**projectmgr** comes with a fallback window in case you aren't using `telescope.nvim`. The same actions are available.
 The keybinds are slightly different: `<C-a>` is replaced by just `a`, `<C-q>` becomes just `q`, and so on.
 
 &nbsp;

--- a/lua/projectmgr/helpers.lua
+++ b/lua/projectmgr/helpers.lua
@@ -72,10 +72,10 @@ function M.check_git(path)
 	return is_git
 end
 
-function M.autogit()
+function M.autogit(command)
 	if M.check_git(".") then
-		local _ = io.popen("git fetch && git pull")
-		print("[ProjectMgr] git repo found, fetching && pulling...")
+		local _ = io.popen(command)
+		print("[ProjectMgr] git repo found, pulling...")
 	end
 end
 

--- a/lua/projectmgr/init.lua
+++ b/lua/projectmgr/init.lua
@@ -7,7 +7,10 @@ local M = {}
 local setup_completed = false
 
 local default_config = {
-	autogit = false,
+	autogit = {
+		enabled = false,
+		command = "git pull --ff-only",
+	},
 	reopen = false,
 	session = { enabled = true, file = "Session.vim" },
 	shada = { enabled = false, file = "main.shada" },
@@ -24,7 +27,7 @@ function M.setup(config)
 	end
 	config = config or {}
 	vim.validate({
-		autogit = { config.autogit, "b", true },
+		autogit = { config.autogit, "t", true },
 		reopen = { config.reopen, "b", true },
 		session = { config.session, "t", true },
 		shada = { config.shada, "t", true },

--- a/lua/projectmgr/manage.lua
+++ b/lua/projectmgr/manage.lua
@@ -17,8 +17,8 @@ function M.open_project(name)
 
 	api.nvim_command("cd " .. path)
 
-	if M.config.autogit then
-		helpers.autogit()
+	if M.config.autogit.enabled then
+		helpers.autogit(M.config.autogit.command)
 	end
 
 	if M.config.session.enabled and helpers.file_exists(M.config.session.file) then


### PR DESCRIPTION
Allow user to specify autogit command and add more sensible default.

BREAKING: if you have disabled autogit in your config, you will need to change

```lua
autogit = false
```
to
```lua
autogit = { enabled = false }
```