### PR TITLE
Adds git info support for windows

### DIFF
--- a/lua/projectmgr/helpers.lua
+++ b/lua/projectmgr/helpers.lua
@@ -61,7 +61,7 @@ end
 function M.check_git(path)
 	local is_git = false
 	local handle =
-		io.popen("git -C " .. M.remove_trailing_slash(path) .. " rev-parse --is-inside-work-tree 2>/dev/null")
+		io.popen("git -C '" .. M.remove_trailing_slash(path) .. "' rev-parse --is-inside-work-tree 2>/dev/null")
 	if handle ~= nil then
 		local check_result = handle:read("*a")
 		if string.find(check_result, "true") then
@@ -98,11 +98,11 @@ function M.git_info(path)
 		return "✗", "✗", "✗"
 	end
 	local current_branch =
-		M.call_ext("git -C " .. M.remove_trailing_slash(path) .. "/.git rev-parse --abbrev-ref HEAD 2>/dev/null")
+		M.call_ext("git -C '" .. M.remove_trailing_slash(path) .. "/.git' rev-parse --abbrev-ref HEAD 2>/dev/null")
 	local tracking_branch = M.call_ext(
-		"git -C "
+		"git -C '"
 			.. M.remove_trailing_slash(path)
-			.. "/.git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null"
+			.. "/.git' rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null"
 	)
 
 	return M.symbolize(current_branch), M.symbolize(tracking_branch)

--- a/lua/projectmgr/platform/unix_platform.lua
+++ b/lua/projectmgr/platform/unix_platform.lua
@@ -1,0 +1,24 @@
+local UNIX = {}
+
+function UNIX.remove_trailing_slash(str)
+	str = str:gsub("(.*)/$", "%1")
+	return str
+end
+
+function UNIX.inside_tree_cmd(path)
+	return "git -C '" .. UNIX.remove_trailing_slash(path) ..
+	  "' rev-parse --is-inside-work-tree 2>/dev/null"
+end
+
+function UNIX.get_git_branch(path)
+	return "git -C '" .. UNIX.remove_trailing_slash(path) ..
+	  "/.git' rev-parse --abbrev-ref HEAD 2>/dev/null"
+end
+
+function UNIX.get_tracking_branch(path)
+	return "git -C '" .. UNIX.remove_trailing_slash(path)
+		.. "/.git' rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null"
+end
+
+return UNIX
+

--- a/lua/projectmgr/platform/win32_platform.lua
+++ b/lua/projectmgr/platform/win32_platform.lua
@@ -1,0 +1,44 @@
+local WIN32 = {}
+
+local IS_POWERSHELL = vim.o.shell:find("powershell.exe")
+local IS_CMD = vim.o.shell:find("cmd.exe")
+
+function WIN32.remove_trailing_slash(str)
+	str = str:gsub("(.*)\\$", "%1")
+	str = str:gsub("\\ ", " ")
+	return str
+end
+
+function WIN32.add_shell_ending(cmd)
+	if IS_POWERSHELL then
+		return cmd .. " 2>$null"
+	elseif IS_CMD then
+		return cmd .. " 2> NUL"
+	else
+		vim.notify("Uknown windows shell")
+		return cmd
+	end
+end
+
+function WIN32.inside_tree_cmd(path)
+	local cmd_string = "git -C \"" ..
+			WIN32.remove_trailing_slash(path) .. "\" rev-parse --is-inside-work-tree"
+
+	return WIN32.add_shell_ending(cmd_string)
+end
+
+function WIN32.get_git_branch(path)
+	local cmd_string = "git -C \"" ..
+		WIN32.remove_trailing_slash(path) .. "\\.git\" rev-parse --abbrev-ref HEAD"
+
+	return WIN32.add_shell_ending(cmd_string)
+end
+
+function WIN32.get_tracking_branch(path)
+	local cmd_string = "git -C \"" .. WIN32.remove_trailing_slash(path)
+		.. "\\.git\" rev-parse --abbrev-ref --symbolic-full-name @{u}"
+
+	return WIN32.add_shell_ending(cmd_string)
+end
+
+return WIN32


### PR DESCRIPTION
This patch fixes #22 which adds git info support for windows. It is implemented just like the Linux version (ie using subprocess shells). Unfortunately on windows processes are much heavier so it is pretty slow. I think to get it as fast as the Linux version we would have to depend on something like [luagit2](https://github.com/libgit2/luagit2).

I'm not sure if luagit2 ships with the actual C library or that needs to be installed separately. It's up to you whether or not this patch set is good enough or I should explore using the libgit2 bindings for windows.